### PR TITLE
made chafa the main preview renderer

### DIFF
--- a/por-cli
+++ b/por-cli
@@ -55,13 +55,7 @@ spinner() {
 
 preview(){
   local img="$1"
-  if [ -n "$TERMUX_VERSION" ]; then
-    curl -s -x "$PROXY" "$img" | chafa --size=${FZF_PREVIEW_COLUMNS}x${FZF_PREVIEW_LINES} -
-    return
-  else
-    curl -s -x "$PROXY" "$img" | kitty icat --clear --transfer-mode=memory --stdin=yes --place=${FZF_PREVIEW_COLUMNS}x${FZF_PREVIEW_LINES}@0x0
-    return
-  fi
+  curl -s -x "$PROXY" "$img" | chafa --size=${FZF_PREVIEW_COLUMNS}x${FZF_PREVIEW_LINES} -
 }
 
 player () {


### PR DESCRIPTION
making chafa the primary image renderer 
- it uses symbols, kitty, sixels and iterm on its own
- works on foot, termux, and all the terminals which allow image rendering too


## Question 
would love to checkout other alternatives too and also getting something to fallback to would be great