### PR TITLE
fix: correct spankbang fzf preview syntax error

### DIFF
--- a/por-cli
+++ b/por-cli
@@ -310,7 +310,9 @@ rm "$tmp";
       notify-send -a "por-cli" "Pages loaded" "All $PAGE pages fetched. Select a video."
     } | 
       fzf --prompt="filter:" --layout=reverse --with-shell="bash -c" --delimiter=$'\t' --with-nth=2 \
-      --preview " $(typeset -f preview) preview {3} " \
+      --preview "
+  $(typeset -f preview)
+  preview {3} " \
       --bind "enter:execute(
         $(typeset -f spinner)
         $(typeset -f player)


### PR DESCRIPTION
## Problem
Selecting the **spankbang** provider crashed the preview pane with:
```
bash: -c: line 5: syntax error near unexpected token `preview'
bash: -c: line 5: `} preview 'https://...'
```

## Cause
The spankbang `--preview` string was one line:
```bash
--preview " $(typeset -f preview) preview {3} "
```
`typeset -f preview` expands to the multi-line function body ending with a `}` on its own line. Appending `preview {3}` on that same line produced `} preview '...'`, a syntax error.

## Fix
Put the `preview` call on its own line, matching the working xhamster block:
```bash
--preview "
  $(typeset -f preview)
  preview {3} "
```